### PR TITLE
Added exponential momentum distribution for SingleTrackGenerator

### DIFF
--- a/generators/STSingleTrackGenerator.cc
+++ b/generators/STSingleTrackGenerator.cc
@@ -7,6 +7,7 @@
 #include "TParticlePDG.h"
 #include "TRandom.h"
 #include "TFile.h"
+#include "TF1.h"
 
 void VertexReader::OpenFile(const std::string& t_filename)
 {
@@ -124,7 +125,8 @@ STSingleTrackGenerator::STSingleTrackGenerator()
   fIsCocktail(kFALSE), fBrho(0.),
   fIsDiscreteTheta(kFALSE), fIsDiscretePhi(kFALSE),
   fNStepTheta(0), fNStepPhi(0),
-  fGausMomentum(kFALSE), fGausMomentumMean(0), fGausMomentumSD(0)
+  fGausMomentum(kFALSE), fGausMomentumMean(0), fGausMomentumSD(0),
+  fExpMomentum(kFALSE), fExpTemperature(25.0)
 {
   fPdgList.clear();
   fMomentum.SetXYZ(0., 0., .5);
@@ -322,6 +324,20 @@ Bool_t STSingleTrackGenerator::ReadEvent(FairPrimaryGenerator* primGen)
       if(fGausMomentum){
         Double_t mom = gRandom->Gaus(fGausMomentumMean, fGausMomentumSD);
         momentum.SetMag(fabs(mom));
+      }
+
+      if(fExpMomentum){
+        // Get particle mass from PDG database
+        TParticlePDG* part = TDatabasePDG::Instance()->GetParticle(pdg);
+        Double_t mass_GeV = part ? part->Mass() : 0.938272; // default to proton mass if not found
+        
+        // Create temporary function for exponential momentum distribution
+        TF1 expFunc("temp_exp_mom", "x*x * exp(-(sqrt(x*x + [1]*[1]) - [1])/([0]/1000.0))", 
+                    fMomentumRange[0], fMomentumRange[1]);
+        expFunc.SetParameters(fExpTemperature, mass_GeV);
+        
+        Double_t mom = expFunc.GetRandom();
+        momentum.SetMag(mom);
       }
 
       if(fUniRandomDirection){

--- a/generators/STSingleTrackGenerator.hh
+++ b/generators/STSingleTrackGenerator.hh
@@ -128,6 +128,7 @@ class STSingleTrackGenerator : public FairGenerator
     void SetThetaLimit(Double_t t0, Double_t t1) { fThetaRange[0] = t0; fThetaRange[1] = t1; }
     void SetPhiLimit(Double_t p0, Double_t p1)   { fPhiRange[0] = p0; fPhiRange[1] = p1; }
     void SetGausMomentum(Double_t mean, Double_t sd) {fGausMomentum = kTRUE; fGausMomentumMean = mean; fGausMomentumSD = sd;}
+    void SetExponentialMomentum(Double_t T_MeV, Double_t minMom, Double_t maxMom) {fExpMomentum = kTRUE; fExpTemperature = T_MeV; fMomentumRange[0] = minMom; fMomentumRange[1] = maxMom;}
     void SetGausPhi(Double_t mean, Double_t sd) {fGausPhi = kTRUE; fGausPhiMean = mean; fGausPhiSD = sd;}
     void SetGausTheta(Double_t mean, Double_t sd) {fGausTheta = kTRUE; fGausThetaMean = mean; fGausThetaSD = sd;}
     void SetPhaseSpaceCut(const std::string& filename);
@@ -176,6 +177,8 @@ class STSingleTrackGenerator : public FairGenerator
     Bool_t   fGausMomentum;
     Double_t fGausMomentumMean;
     Double_t fGausMomentumSD;
+    Bool_t   fExpMomentum;
+    Double_t fExpTemperature;
     Bool_t   fGausTheta;
     Double_t fGausThetaMean;
     Double_t fGausThetaSD;


### PR DESCRIPTION
Included a minor method to generate an exponential momentum distribution from:
e^(-E/T)

- User needs to adjust the T value (MeV)
- Method gets the mass of the particle automatically from the generator 
- Generate momentum distribution as f(p) = p² × (p/√(p² + m²)) × e^(-(√(p² + m²) - m)/T)  // this takes into account the Jacobian factor and the phase space factor